### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,4 @@
+bom: pcb-kicad/Muino_debugger.kicad_pcb
+eda:
+  type: kicad
+  pcb: pcb-kicad/Muino_debugger.kicad_pcb


### PR DESCRIPTION
Hi, this adds a file that allows us to create a [kitspace.org](https://kitspace.org) page for your project.  Kitspace tries to make it easier for people to build OSHW electronics projects. Here is a preview of what the page will look like: http://try-pico-probe.preview.kitspace.org/boards/github.com/kitspace-forks/pico-probe-programmer/

Some things to note:

- If you merge this, the Kitspace page will be created under your name and it will keep staying in sync with your repo automatically (re-syncs every 3 hours or so)
- The Gerbers offered on Kitspace are currently auto plotted from the .kicad_pcb file. If you'd rather use the Gerbers you have in the repo you can add `gerbers: pcb-readyto-order` into the yaml.
- The BOM is also currently generated from the .kicad_pcb and doesn't have any "purchasable parts" (distributor SKUs). You can change the `bom:` field to point to something else in the future (.xlsx, .ods, .csv etc.). We also have an editor, called the [BOM Builder](https://kitspace.org/bom-builder), that helps you select purchasable parts, I can give you free access if you are interested. 

